### PR TITLE
feat: prevent wz edits via server checksum checks

### DIFF
--- a/launcher/v214/main/OutPackets.cs
+++ b/launcher/v214/main/OutPackets.cs
@@ -3,23 +3,41 @@ namespace Swordie
 {
     internal class OutPackets
     {
-        public static OutPacket AuthRequest(string username, string pwd)
+        public static OutPacket AuthRequest(
+            string username,
+            string password
+        )
         {
-            OutPacket outPacket = new OutPacket((short)100);
+            OutPacket outPacket = new OutPacket((short) 100);
             outPacket.WriteString(username);
-            outPacket.WriteString(pwd);
+            outPacket.WriteString(password);
+
             return outPacket;
         }
 
         public static OutPacket CreateAccountRequest(
-          string username,
-          string pwd,
-          string email)
+            string username,
+            string password,
+            string email
+        )
         {
-            OutPacket outPacket = new OutPacket((short)101);
+            OutPacket outPacket = new OutPacket((short) 101);
             outPacket.WriteString(username);
-            outPacket.WriteString(pwd);
+            outPacket.WriteString(password);
             outPacket.WriteString(email);
+
+            return outPacket;
+        }
+
+        public static OutPacket FileChecksum(
+            string filename,
+            string checksum
+        )
+        {
+            OutPacket outPacket = new OutPacket((short) 102);
+            outPacket.WriteString(filename);
+            outPacket.WriteString(checksum);
+
             return outPacket;
         }
     }

--- a/server/src/main/java/net/swordie/ms/connection/api/ApiAcceptor.java
+++ b/server/src/main/java/net/swordie/ms/connection/api/ApiAcceptor.java
@@ -19,7 +19,6 @@ import static net.swordie.ms.connection.netty.NettyClient.CLIENT_KEY;
  * Created on 10/5/2018.
  */
 public class ApiAcceptor implements Runnable {
-
     private static final Logger log = Logger.getLogger(ApiAcceptor.class);
 
     @Override

--- a/server/src/main/java/net/swordie/ms/connection/api/ApiEncoder.java
+++ b/server/src/main/java/net/swordie/ms/connection/api/ApiEncoder.java
@@ -29,7 +29,6 @@ public class ApiEncoder extends MessageToByteEncoder<Packet> {
 
             bb.writeInt(data.length);
             bb.writeBytes(data);
-
         } else {
             log.debug("[PacketEncoder] | Plain sending " + outPacket);
             bb.writeBytes(data);

--- a/server/src/main/java/net/swordie/ms/connection/api/ApiHandler.java
+++ b/server/src/main/java/net/swordie/ms/connection/api/ApiHandler.java
@@ -25,19 +25,27 @@ public class ApiHandler extends SimpleChannelInboundHandler<InPacket> {
         Client c = (Client) ctx.channel().attr(CLIENT_KEY).get();
         short op = inPacket.decodeShort();
         ApiInHeader opHeader = ApiInHeader.getByVal(op);
-        if(opHeader == null) {
+
+        if (opHeader == null) {
             handleUnknown(inPacket, op);
             return;
         }
+
         if(!InHeader.isSpamHeader(InHeader.getInHeaderByOp(op))) {
             log.debug(String.format("[API In]\t| %s, %d/0x%s\t| %s", InHeader.getInHeaderByOp(op), op, Integer.toHexString(op).toUpperCase(), inPacket));
         }
+
         switch (opHeader) {
             case REQUEST_TOKEN:
                 ApiRequestHandler.handleTokenRequest(c, inPacket);
                 break;
+
             case CREATE_ACCOUNT_REQUEST:
                 ApiRequestHandler.handleCreateAccountRequest(c, inPacket);
+                break;
+
+            case CHECK_FILE_CHECKSUM:
+                ApiRequestHandler.handleCheckFileChecksum(c, inPacket);
                 break;
         }
     }

--- a/server/src/main/java/net/swordie/ms/connection/api/ApiInHeader.java
+++ b/server/src/main/java/net/swordie/ms/connection/api/ApiInHeader.java
@@ -9,6 +9,7 @@ import net.swordie.ms.util.Util;
 public enum ApiInHeader {
     REQUEST_TOKEN(100),
     CREATE_ACCOUNT_REQUEST(101),
+    CHECK_FILE_CHECKSUM(102),
     ;
 
     private int val;

--- a/server/src/main/java/net/swordie/ms/connection/api/ApiOutHeader.java
+++ b/server/src/main/java/net/swordie/ms/connection/api/ApiOutHeader.java
@@ -9,6 +9,7 @@ import net.swordie.ms.util.Util;
 public enum ApiOutHeader {
     REQUEST_TOKEN_RESULT(100),
     CREATE_ACCOUNT_RESULT(101),
+    CHECK_FILE_CHECKSUM_RESULT(102),
     ;
 
     private int val;

--- a/server/src/main/java/net/swordie/ms/connection/packet/ApiResponse.java
+++ b/server/src/main/java/net/swordie/ms/connection/packet/ApiResponse.java
@@ -4,6 +4,7 @@ import net.swordie.ms.connection.OutPacket;
 import net.swordie.ms.connection.api.ApiOutHeader;
 import net.swordie.ms.enums.AccountCreateResult;
 import net.swordie.ms.enums.ApiTokenResultType;
+import net.swordie.ms.enums.FileChecksumResult;
 import net.swordie.ms.handlers.ApiRequestHandler;
 
 /**
@@ -27,7 +28,14 @@ public class ApiResponse {
         OutPacket outPacket = new OutPacket(ApiOutHeader.CREATE_ACCOUNT_RESULT);
 
         outPacket.encodeByte(acr.ordinal());
-//work?
+        //work?
+        return outPacket;
+    }
+
+    public static OutPacket checkFileChecksumResult(FileChecksumResult fcr) {
+        OutPacket outPacket = new OutPacket(ApiOutHeader.CHECK_FILE_CHECKSUM_RESULT);
+        outPacket.encodeByte(fcr.ordinal());
+
         return outPacket;
     }
 }

--- a/server/src/main/java/net/swordie/ms/enums/FileChecksumResult.java
+++ b/server/src/main/java/net/swordie/ms/enums/FileChecksumResult.java
@@ -1,0 +1,11 @@
+package net.swordie.ms.enums;
+
+/**
+ * @author Toxocious
+ * Created on 05/09/2023.
+ */
+
+public enum FileChecksumResult {
+    Success,
+    Failure,
+}

--- a/server/src/main/java/net/swordie/ms/handlers/ApiRequestHandler.java
+++ b/server/src/main/java/net/swordie/ms/handlers/ApiRequestHandler.java
@@ -7,34 +7,61 @@ import net.swordie.ms.client.User;
 import net.swordie.ms.connection.InPacket;
 import net.swordie.ms.connection.db.DatabaseManager;
 import net.swordie.ms.connection.packet.ApiResponse;
+import net.swordie.ms.connection.packet.Login;
 import net.swordie.ms.constants.GameConstants;
 import net.swordie.ms.enums.AccountCreateResult;
+import net.swordie.ms.enums.FileChecksumResult;
 import net.swordie.ms.enums.AccountType;
 import net.swordie.ms.enums.ApiTokenResultType;
 import net.swordie.ms.util.Util;
 import org.apache.log4j.Logger;
 import org.mindrot.jbcrypt.BCrypt;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * @author Sjonnie
  * Created on 10/5/2018.
  */
 public class ApiRequestHandler {
-
     private static final Logger log = Logger.getLogger(ApiRequestHandler.class);
     private static final int TOKEN_LENGTH = 50;
+
+    private static final Map<String, String> expected_checksums = new HashMap<String, String>() {{
+        put("Character", "80a5dbda09f0d4c2deef483a43357f6a");
+        put("Data", "8a2f0c581fe80acbb475de0fa957acf5");
+        put("Etc", "97505eb28654e6f79a331e3032b6a27a");
+        put("Item", "0734c1003e859c0dadd3ed9b6a4ac422");
+        put("Map", "cb7218f83d02cafb2a4de3b2102a97cd");
+        put("Map001", "90c727a20bb855aa8b08c8c8e657037c");
+        put("Map002", "fe041aee6c9af90ae4c6f6bd14a7ef27");
+        put("Map2", "f0cc8c815d1592462a8575be2bd8627d");
+        put("Mob", "17669211382353a375128ffee9844501");
+        put("Mob001", "d858a2f98196cf0d189ce0fcf9da1a6c");
+        put("Mob2", "15195ab866e521a4a05826499ce63abb");
+        put("Npc", "e7cbc8e27e60b5cea3747601650654f3");
+        put("Quest", "9f3f6e97811895916b2aed45740ff1bf");
+        put("Skill", "3561c2d424d797543b5fe6db22adb513");
+        put("Skill001", "6e379f832193365d7d9f8df9541974ed");
+        put("Skill002", "5b24f097af12103079cf53e818dd937e");
+        put("UI", "eaefc622a93956fc8b99a3011241794a");
+    }};
 
     public static void handleTokenRequest(Client c, InPacket inPacket) {
         String name = inPacket.decodeString();
         String password = inPacket.decodeString();
         User user = User.getFromDBByName(name);
+
         ApiTokenResultType atrt;
         boolean success = false;
+
         if (user == null) {
             atrt = ApiTokenResultType.InvalidUserPassCombination;
         } else {
             String dbPassword = user.getPassword();
             boolean hashed = Util.isStringBCrypt(dbPassword);
+
             if (hashed) {
                 try {
                     success = BCrypt.checkpw(password, dbPassword);
@@ -46,18 +73,23 @@ public class ApiRequestHandler {
                 success = password.equals(dbPassword);
             }
         }
+
         byte[] token = new byte[]{};
+
         if (success) {
             atrt = ApiTokenResultType.Success;
             // Generate token
             token = new byte[TOKEN_LENGTH];
+
             for (int i = 0; i < token.length; i++) {
                 token[i] = (byte) Util.getRandom('0', '~');
             }
+
             Server.getInstance().addAuthToken(token, user.getId());
         } else {
             atrt = ApiTokenResultType.InvalidUserPassCombination;
         }
+
         c.write(ApiResponse.tokenRequestResult(atrt, new String(token)));
     }
 
@@ -66,6 +98,7 @@ public class ApiRequestHandler {
         String pwd = inPacket.decodeString();
         String email = inPacket.decodeString();
         AccountCreateResult acr = AccountCreateResult.Success;
+
         if (User.getFromDBByName(name) != null) {
             acr = AccountCreateResult.NameInUse;
         } /*else if (Account.getFromDBByIp(c.getIP()) != null) {
@@ -73,6 +106,7 @@ public class ApiRequestHandler {
         } */ else if (name.length() < 4 || pwd.length() < 4) {
             acr = AccountCreateResult.Unknown;
         }
+
         if (acr == AccountCreateResult.Success) {
             User user = new User(name);
             user.setHashedPassword(pwd);
@@ -81,6 +115,16 @@ public class ApiRequestHandler {
             user.setCharacterSlots(ServerConstants.MAX_CHARACTERS / 2);
             DatabaseManager.saveToDB(user);
         }
+
         c.write(ApiResponse.createAccountResult(acr));
+    }
+
+    public static void handleCheckFileChecksum(Client c, InPacket inPacket) {
+        String received_filename = inPacket.decodeString();
+        String received_checksum = inPacket.decodeString();
+
+        FileChecksumResult fcr = expected_checksums.get(received_filename).toString().equals(received_checksum) ? FileChecksumResult.Success : FileChecksumResult.Failure;
+
+        c.write(ApiResponse.checkFileChecksumResult(fcr));
     }
 }

--- a/server/src/main/java/net/swordie/ms/handlers/LoginHandler.java
+++ b/server/src/main/java/net/swordie/ms/handlers/LoginHandler.java
@@ -59,7 +59,6 @@ import org.apache.log4j.Logger;
 public class LoginHandler {
     private static final org.apache.log4j.Logger log = LogManager.getRootLogger();
 
-
     @Handler(op = InHeader.PERMISSION_REQUEST)
     public static void handlePermissionRequest(Client c, InPacket inPacket) {
         byte locale = inPacket.decodeByte();
@@ -71,7 +70,7 @@ public class LoginHandler {
         }
     }
 
-        @Handler(op = InHeader.USE_AUTH_SERVER)
+    @Handler(op = InHeader.USE_AUTH_SERVER)
     public static void handleAuthServer(Client client, InPacket inPacket) {
            // client.write(Login.sendAuthServer(false));
     }
@@ -151,20 +150,23 @@ public class LoginHandler {
         c.write(Login.checkPasswordResult(success, result, user));
     }
 
-        @Handler(ops = {InHeader.WORLD_INFO_REQUEST, InHeader.WORLD_LIST_REQUEST})
+    @Handler(ops = {InHeader.WORLD_INFO_REQUEST, InHeader.WORLD_LIST_REQUEST})
     public static void handleWorldListRequest(Client c, InPacket inPacket) {
         if (c.getAccount() != null) {
             DatabaseManager.saveToDB(c.getAccount());
             c.setAccount(null);
         }
-        //String[] bgs = new String[]{"Adventure", "adventurePathfinder"};
-        String[] bgs = new String[]{"adele"};
+
+        String[] bgs = new String[]{ "adele" };
+
         c.write(MapLoadable.setMapTaggedObjectVisisble(Collections.singleton(
                 new MapTaggedObject(String.format("%s", Util.getRandomFromCollection(bgs)), true)
         )));
+
         for (World world : Server.getInstance().getWorlds()) {
             c.write(Login.sendWorldInformation(world, null));
         }
+
         c.write(Login.sendWorldInformationEnd());
         c.write(Login.sendRecommendWorldMessage(ServerConfig.WORLD_ID, ServerConfig.RECOMMEND_MSG));
     }

--- a/server/src/main/java/net/swordie/ms/handlers/header/OutHeader.java
+++ b/server/src/main/java/net/swordie/ms/handlers/header/OutHeader.java
@@ -2139,6 +2139,7 @@ public enum OutHeader {
     // CField::OnPacket v210?
     UNK204_2042(-1),
 
+    CHECK_FILE_CHECKSUM(9998),
 
     NO(9999),
     ;


### PR DESCRIPTION
In order to deter against malicious players who would attempt to "WZ edit" in order to gain massively unfair advantages against other players, Moonlight now verifies that the client's WZ files match the checksum that the server expects.

If Moonlight were to ever add custom content through WZ editing (custom user-interface elements, etc.) the list of checksums in the [ApiRequestHandler](./server/src/main/java/net/swordie/ms/handlers/ApiRequestHandler.java) would have to be updated to match the checksums of the edited WZ files.

It's worth noting that we don't verify the integrity of **every** WZ file, but rather the more important ones that are typically edited with malicious intent.
This can, of course, be very easily updated if the need arises to verify the integrity of any other WZ file, but for now this should be fine.

**Integrity Checked**:
- Character
- Data
- Etc
- Item
- Map
- Map001
- Map002
- Map2
- Mob
- Mob001
- Mob2
- Npc
- Quest
- Skill
- Skill001
- Skill002
- UI